### PR TITLE
Cdp layout

### DIFF
--- a/projects/telescope-extension/src/app/views/cdp/cdp.component.html
+++ b/projects/telescope-extension/src/app/views/cdp/cdp.component.html
@@ -10,76 +10,76 @@
 <mat-card>
   <mat-list *ngFor="let collateral of params?.collateral_params">
     <mat-list-item>
-      <span class="column-name">Denom:</span>
+      <span>Denom:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ collateral.denom }}</span>
+      <span>{{ collateral.denom }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
-      <span class="column-name">Type:</span>
+      <span>Type:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ collateral.type }}</span>
+      <span>{{ collateral.type }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
-      <span class="column-name">Liquidation Ratio:</span>
+      <span>Liquidation Ratio:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ collateral.liquidation_ratio | number:'1.6-6' }}</span>
+      <span>{{ collateral.liquidation_ratio | number:'1.6-6' }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
-      <span class="column-name">Debt Limit:</span>
+      <span>Debt Limit:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ collateral.debt_limit?.amount | number:'1.0-0' }}</span>
+      <span>{{ collateral.debt_limit?.amount | number:'1.0-0' }}</span>
       <span class="ml-1">{{ collateral.debt_limit?.denom }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
-      <span class="column-name">Stability Fee:</span>
+      <span>Stability Fee:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ collateral.stability_fee}}</span>
+      <span>{{ collateral.stability_fee}}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
-      <span class="column-name">Auction Size:</span>
+      <span>Auction Size:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ collateral.auction_size | number:'1.0-0' }}</span>
+      <span>{{ collateral.auction_size | number:'1.0-0' }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
-      <span class="column-name">Liquidation Penalty:</span>
+      <span>Liquidation Penalty:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ collateral.liquidation_penalty | number:'1.6-6' }}</span>
+      <span>{{ collateral.liquidation_penalty | number:'1.6-6' }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
-      <span class="column-name">Spot Market ID:</span>
+      <span>Spot Market ID:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ collateral.spot_market_id }}</span>
+      <span>{{ collateral.spot_market_id }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
-      <span class="column-name">Liquidation Market ID:</span>
+      <span>Liquidation Market ID:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ collateral.liquidation_market_id }}</span>
+      <span>{{ collateral.liquidation_market_id }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
-      <span class="column-name">Keeper Reward Percentage:</span>
+      <span>Keeper Reward Percentage:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ collateral.keeper_reward_percentage | number:'1.9-9' }}</span>
+      <span>{{ collateral.keeper_reward_percentage | number:'1.9-9' }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
-      <span class="column-name">Check Collateralization Index Count:</span>
+      <span>Check Collateralization Index Count:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ collateral.check_collateralization_index_count | number:'1.0-0' }}</span>
+      <span>{{ collateral.check_collateralization_index_count | number:'1.0-0' }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
-      <span class="column-name">Conversion Factor:</span>
+      <span>Conversion Factor:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ collateral.conversion_factor }}</span>
+      <span>{{ collateral.conversion_factor }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
   </mat-list>
@@ -89,27 +89,27 @@
 <mat-card>
   <mat-list>
     <mat-list-item>
-      <span class="column-name">Denom:</span>
+      <span>Denom:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ params?.debt_param?.denom }}</span>
+      <span>{{ params?.debt_param?.denom }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
-      <span class="column-name">Reference Asset:</span>
+      <span>Reference Asset:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ params?.debt_param?.reference_asset }}</span>
+      <span>{{ params?.debt_param?.reference_asset }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
-      <span class="column-name">Conversion Factor:</span>
+      <span>Conversion Factor:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ params?.debt_param?.conversion_factor }}</span>
+      <span>{{ params?.debt_param?.conversion_factor }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
-      <span class="column-name">Debt Floor:</span>
+      <span>Debt Floor:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ params?.debt_param?.debt_floor }}</span>
+      <span>{{ params?.debt_param?.debt_floor }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
   </mat-list>
@@ -119,40 +119,40 @@
 <mat-card>
   <mat-list>
     <mat-list-item>
-      <span class="column-name">Global Debt Limit:</span>
+      <span>Global Debt Limit:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ params?.global_debt_limit?.amount | number:'1.0-0' }}</span>
+      <span>{{ params?.global_debt_limit?.amount | number:'1.0-0' }}</span>
       <span class="ml-1">{{ params?.global_debt_limit?.denom }}</span>
     </mat-list-item>
     <mat-divider></mat-divider>
     <mat-list-item>
-      <span class="column-name">Surplus Auction Threshold:</span>
+      <span>Surplus Auction Threshold:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ params?.surplus_auction_threshold | number:'1.0-0' }}</span>
+      <span>{{ params?.surplus_auction_threshold | number:'1.0-0' }}</span>
     </mat-list-item>
     <mat-divider></mat-divider>
     <mat-list-item>
-      <span class="column-name">Surplus Auction Lot:</span>
+      <span>Surplus Auction Lot:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ params?.surplus_auction_lot | number:'1.0-0' }}</span>
+      <span>{{ params?.surplus_auction_lot | number:'1.0-0' }}</span>
     </mat-list-item>
     <mat-divider></mat-divider>
     <mat-list-item>
-      <span class="column-name">Debt Auction Threshold:</span>
+      <span>Debt Auction Threshold:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ params?.debt_auction_threshold | number:'1.0-0' }}</span>
+      <span>{{ params?.debt_auction_threshold | number:'1.0-0' }}</span>
     </mat-list-item>
     <mat-divider></mat-divider>
     <mat-list-item>
-      <span class="column-name">Debt Auction Lot:</span>
+      <span>Debt Auction Lot:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ params?.debt_auction_lot | number:'1.0-0' }}</span>
+      <span>{{ params?.debt_auction_lot | number:'1.0-0' }}</span>
     </mat-list-item>
     <mat-divider></mat-divider>
     <mat-list-item>
-      <span class="column-name">Circuit Breaker:</span>
+      <span>Circuit Breaker:</span>
       <span class="flex-auto"></span>
-      <span class="column-value">{{ params?.circuit_breaker }}</span>
+      <span>{{ params?.circuit_breaker }}</span>
     </mat-list-item>
     <mat-divider></mat-divider>
   </mat-list>


### PR DESCRIPTION
[telecsope feat: fix_layout_for_mobile #175](https://github.com/lcnem/telescope/pull/175)に対応する修正です。
ご確認お願い致します。
![20211020_cdp_layout](https://user-images.githubusercontent.com/75844498/138093759-cbacd5f0-6e0d-48b5-b87f-5c9ad0620dcf.png)
※コミット分けて、使用していなかったCSSを削除しております。
　折り返しや文字サイズ変更などの修飾が必要ない箇所はクラスタグを削除するのみとしています。