### PR TITLE
fix: sidenav link from routerlink to href

### DIFF
--- a/projects/telescope-extension/src/app/views/app.component.html
+++ b/projects/telescope-extension/src/app/views/app.component.html
@@ -9,26 +9,33 @@
     </mat-toolbar>
 
     <mat-nav-list>
-      <mat-list-item routerLink="/">
-        <mat-icon class="mr-2" color="primary">other_houses</mat-icon>Home
+      <mat-list-item href="/">
+        <mat-icon class="mr-2" color="primary">other_houses</mat-icon>
+        Home
       </mat-list-item>
-      <mat-list-item routerLink="/blocks">
-        <mat-icon class="mr-2" color="primary">account_tree</mat-icon>Blocks
+      <mat-list-item href="/blocks">
+        <mat-icon class="mr-2" color="primary">account_tree</mat-icon>
+        Blocks
       </mat-list-item>
-      <mat-list-item routerLink="/txs">
-        <mat-icon class="mr-2" color="primary">mail</mat-icon>Txs
+      <mat-list-item href="/txs">
+        <mat-icon class="mr-2" color="primary">mail</mat-icon>
+        Txs
       </mat-list-item>
-      <mat-list-item routerLink="/keys">
-        <mat-icon class="mr-2" color="primary">manage_accounts</mat-icon>Keys
+      <mat-list-item href="/keys">
+        <mat-icon class="mr-2" color="primary">manage_accounts</mat-icon>
+        Keys
       </mat-list-item>
-      <mat-list-item routerLink="/cosmos/bank">
-        <mat-icon class="mr-2" color="primary">sync_alt</mat-icon>Bank
+      <mat-list-item href="/cosmos/bank">
+        <mat-icon class="mr-2" color="primary">sync_alt</mat-icon>
+        Bank
       </mat-list-item>
-      <mat-list-item routerLink="/cosmos/staking">
-        <mat-icon class="mr-2" color="primary">savings</mat-icon>Staking
+      <mat-list-item href="/cosmos/staking">
+        <mat-icon class="mr-2" color="primary">savings</mat-icon>
+        Staking
       </mat-list-item>
-      <mat-list-item routerLink="/cosmos/gov">
-        <mat-icon class="mr-2" color="primary">message</mat-icon>Gov
+      <mat-list-item href="/cosmos/gov">
+        <mat-icon class="mr-2" color="primary">message</mat-icon>
+        Gov
       </mat-list-item>
       <ng-template ngFor let-extension [ngForOf]="extensionNavigations">
         <ng-container *ngIf="extension?.name && extension?.link">


### PR DESCRIPTION
@KimuraYu45z cc: @taro04 @Senna46 
レビューお願いします。

botany側SPA内に表示されているtelescope側SPAのサイドナビリンクが、hrefからrouterLinkに変わっていて、同一SPA内でrouterLinkで指定されたパスが見つからずエラーになって、サイドナビが機能しなくなっていたのを修正しました。
(ついでに、改行入れたほうが良いと思ったところに改行いれています。)