### PR TITLE
fix: cd of lp with workaround way only hosting

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -30,4 +30,4 @@ jobs:
       - run: npm run build --if-present -- --configuration=production --project=main
       - run: npm ci
         working-directory: ./functions
-      - run: npx firebase deploy --project=default --token=${{ secrets.FIREBASE_TOKEN }}
+      - run: npx firebase deploy --only hosting --project=default --token=${{ secrets.FIREBASE_TOKEN }}


### PR DESCRIPTION
cc: @KimuraYu45z cc: @taro04 @Senna46 
レビューお願いします。

FirebaseへのCDが、functionsのところで問題がおきて機能していないように見えたので、いったんonly hostingオプションで回避しておく形で対応する内容です。